### PR TITLE
fix: digest collect 프로세스 행 수정 + 보일러플레이트 제거

### DIFF
--- a/scripts/collect-feeds.mjs
+++ b/scripts/collect-feeds.mjs
@@ -104,7 +104,14 @@ async function main() {
   log('by category:', JSON.stringify(byCat));
 }
 
-main().catch((err) => {
-  console.error('[digest] FATAL:', err);
-  process.exit(1);
-});
+main()
+  .then(() => {
+    // rss-parser may leave keep-alive sockets open, which keeps the Node event
+    // loop alive and hangs the process (and the CI step) after work is done.
+    // Exit explicitly now that all output is written synchronously.
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error('[digest] FATAL:', err);
+    process.exit(1);
+  });

--- a/scripts/lib/digest-feeds.mjs
+++ b/scripts/lib/digest-feeds.mjs
@@ -76,9 +76,22 @@ export function cleanText(s) {
     .trim();
 }
 
+/**
+ * Strip WordPress feed boilerplate like
+ * "The post <title> appeared first on <site>." which many RSS feeds
+ * (e.g. The New Stack) append to every item's content.
+ */
+export function stripBoilerplate(text) {
+  if (!text) return '';
+  return text
+    .replace(/\s*The post\b.*?\bappeared first on\b.*?(?:\.|$)/gi, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
 /** First 1-2 sentences from an RSS description/summary, capped in length. */
 export function excerptFrom(raw, maxLen = 320) {
-  const text = cleanText(raw);
+  const text = stripBoilerplate(cleanText(raw));
   if (!text) return '';
   const sentences = text.match(/[^.!?。]+[.!?。]?/g) || [text];
   let out = '';


### PR DESCRIPTION
## 문제

### 1. collect 프로세스가 종료되지 않고 멈춤 (행)
`scripts/collect-feeds.mjs` 실행 시 RSS 수집·JSON 저장은 정상 완료되지만, `rss-parser`가 keep-alive 소켓을 열어둔 채 남겨 Node 이벤트 루프가 비지 않아 **프로세스가 종료되지 않았습니다** (로컬에서 약 4분 53초 잔류 확인). GitHub Actions의 `Collect RSS feeds` 스텝이 타임아웃까지 멈추게 됩니다.

### 2. 발췌에 WordPress 보일러플레이트 혼입
The New Stack 등 WordPress 기반 피드는 각 글 본문 끝에 `The post <제목> appeared first on <사이트>.` 문구를 붙입니다. 이 문구가 RSS 발췌에 그대로 섞여 들어갑니다.

## 수정

- **행 해결**: 모든 출력이 동기(`writeFileSync`)로 기록되므로, `main()` 완료 후 `process.exit(0)`을 명시 호출해 즉시 종료. 재실행 시 4초 만에 정상 종료 확인.
- **보일러플레이트 제거**: 공용 `excerptFrom`에 `stripBoilerplate`를 추가해 `The post … appeared first on …` 패턴을 정규식으로 제거.

## 검증

- `node scripts/collect-feeds.mjs` → exit 0, 4초 내 종료
- `node scripts/generate-daily-digest.mjs` → exit 0, 생성된 KO/EN 포스트에 `appeared first on` 0건
- 스크립트 전용 변경 (package.json / lock 무관)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
