### PR TITLE
feat: digest --enrich 모드 + Cowork 연동 JSON 스키마 (Phase 2)

### DIFF
--- a/docs/daily-digest.md
+++ b/docs/daily-digest.md
@@ -1,0 +1,88 @@
+# Daily Tech Digest — 파이프라인 가이드
+
+Cloud / Kubernetes / AI / DevOps RSS 피드를 매일 수집해 한/영 다이제스트
+포스트를 자동 생성하는 시스템. **추가 API 비용 없음** — 수집은 GitHub
+Actions, AI 요약(선택)은 Claude 구독(Cowork) 스케줄 태스크로 처리한다.
+
+## 구성 요소
+
+| 파일 | 역할 |
+|---|---|
+| `scripts/collect-feeds.mjs` | RSS 수집 → `.digest-data/YYYY-MM-DD.json` 저장 |
+| `scripts/generate-daily-digest.mjs` | JSON → KO/EN 마크다운 포스트 생성 |
+| `scripts/lib/digest-feeds.mjs` | 피드 목록·카테고리 매핑·발췌 등 공용 헬퍼 |
+| `.github/workflows/daily-digest.yml` | 매일 00:00 UTC(09:00 KST) cron + 수동 실행 |
+
+## npm 스크립트
+
+```bash
+npm run digest:collect          # RSS 수집 → JSON
+npm run digest                  # JSON → 마크다운 (원문 발췌)
+npm run digest -- --enrich      # JSON → 마크다운 (AI 필드 우선, 없으면 발췌 폴백)
+npm run digest -- --date 2026-06-14   # 특정 날짜 재생성
+```
+
+## 데이터 흐름
+
+```
+[GitHub Actions / 매일]
+  collect-feeds.mjs → .digest-data/YYYY-MM-DD.json (원시 데이터)
+  generate-daily-digest.mjs → daily-digest-YYYY-MM-DD(.en).md (원문 발췌)
+  → draft PR 생성
+
+[Cowork 스케줄 태스크 / 선택 · Phase 2]
+  1. .digest-data/YYYY-MM-DD.json 읽기
+  2. Claude가 각 기사에 summaryKo/summaryEn/insightKo/insightEn 추가
+  3. JSON 덮어쓰기
+  4. npm run digest -- --enrich → 보강된 마크다운 재생성
+```
+
+## JSON 스키마 — `.digest-data/YYYY-MM-DD.json`
+
+```jsonc
+{
+  "date": "2026-06-15",            // KST 날짜
+  "generatedAt": "2026-06-15T00:00:00.000Z",
+  "count": 5,
+  "articles": [
+    {
+      // collect-feeds.mjs가 기록 (필수)
+      "source": "Kubernetes",            // 피드 이름
+      "category": "k8s",                 // k8s | ai | cloud | devops
+      "title": "원문 제목",
+      "link": "https://...",
+      "date": "2026-06-14T15:00:00.000Z",
+      "excerpt": "RSS 발췌 1-2문장 (없으면 \"\")",
+
+      // Cowork/Claude가 나중에 추가 (선택) — --enrich 시 우선 사용
+      "summaryKo": "한국어 요약 2-3문장",
+      "summaryEn": "English summary, 2-3 sentences",
+      "insightKo": "왜 중요한가 (Cloud/DevOps 관점) 1문장",
+      "insightEn": "Why it matters, 1 sentence"
+    }
+  ]
+}
+```
+
+### 폴백 규칙 (`--enrich`)
+
+- `summaryKo`/`summaryEn`가 있으면 본문으로 사용, 없으면 `excerpt`로 폴백.
+- `insightKo`/`insightEn`가 있으면 `> 💡 왜 중요한가` 블록으로 표시, 없으면 생략.
+- 한 기사가 summary/excerpt 모두 없으면 "⚡ 빠른 소식" 불릿으로만 노출.
+
+## Cowork 스케줄 태스크 작성 예시 (Phase 2)
+
+> 매일 09:30 KST 실행. `src/content/posts/.digest-data/`에서 오늘 날짜
+> JSON을 찾아 각 article에 `summaryKo`, `summaryEn`, `insightKo`,
+> `insightEn`을 채워 JSON을 덮어쓴 뒤, `npm run digest -- --enrich`를
+> 실행하고 변경된 포스트를 커밋·PR로 올린다. (요약은 Cloud/DevOps
+> 엔지니어 관점, 한국어/영어 각각.)
+
+## 카테고리 매핑 (소스 기반, AI 불필요)
+
+| 카테고리 | 피드 |
+|---|---|
+| Kubernetes & Cloud Native (`k8s`) | Kubernetes, CNCF, AWS Containers |
+| AI & ML (`ai`) | OpenAI, Hugging Face |
+| 클라우드 업데이트 (`cloud`) | Google Cloud |
+| DevOps & 인프라 (`devops`) | HashiCorp, The New Stack, Grafana |

--- a/scripts/collect-feeds.mjs
+++ b/scripts/collect-feeds.mjs
@@ -89,6 +89,35 @@ async function main() {
 
   fs.mkdirSync(DATA_DIR, { recursive: true });
   const outPath = path.join(DATA_DIR, `${date}.json`);
+  /**
+   * Output JSON schema — src/content/posts/.digest-data/YYYY-MM-DD.json
+   *
+   * {
+   *   date: "YYYY-MM-DD",            // KST date
+   *   generatedAt: ISO-8601 string,
+   *   count: number,
+   *   articles: [
+   *     {
+   *       // --- written by this collector ---
+   *       source:   string,          // feed name, e.g. "Kubernetes"
+   *       category: "k8s"|"ai"|"cloud"|"devops",
+   *       title:    string,          // original article title
+   *       link:     string,          // original URL
+   *       date:     ISO-8601 string, // article publish date
+   *       excerpt:  string,          // 1-2 sentence RSS excerpt (may be "")
+   *
+   *       // --- optional, added later by the Phase 2 Cowork/Claude step ---
+   *       // All optional. `generate-daily-digest.mjs --enrich` uses these when
+   *       // present and falls back to `excerpt` per-field when absent.
+   *       summaryKo?: string,        // 2-3 sentence Korean summary
+   *       summaryEn?: string,        // 2-3 sentence English summary
+   *       insightKo?: string,        // 1 sentence "why it matters" (Korean)
+   *       insightEn?: string,        // 1 sentence "why it matters" (English)
+   *     },
+   *     ...
+   *   ]
+   * }
+   */
   const payload = {
     date,
     generatedAt: new Date().toISOString(),

--- a/scripts/generate-daily-digest.mjs
+++ b/scripts/generate-daily-digest.mjs
@@ -8,14 +8,27 @@
  *   src/content/posts/daily-digest-YYYY-MM-DD.md      (Korean labels)
  *   src/content/posts/daily-digest-YYYY-MM-DD-en.md   (English labels)
  *
- * Each article is rendered from its original title, an excerpt taken from the
- * RSS description/summary field, a source-based category, and the original
- * link — no summarization model is involved. (A Cowork scheduled task can
- * later run Claude over the same JSON to attach richer summaries.)
+ * By default each article is rendered from its original title, an excerpt
+ * taken from the RSS description/summary field, a source-based category, and
+ * the original link — no summarization model is involved.
+ *
+ * With --enrich, the script uses AI-authored fields (summaryKo/summaryEn/
+ * insightKo/insightEn) when present in the JSON, falling back to the raw
+ * excerpt per-field when they are absent. This is how the Phase 2 Cowork
+ * scheduled task works: Claude reads the collected JSON, fills in those
+ * optional fields, then this script regenerates the markdown with richer
+ * summaries and "why it matters" insights — all on the Claude subscription,
+ * no extra API cost.
+ *
+ * Optional per-article enrichment fields (see collect-feeds.mjs for the full
+ * schema): summaryKo, summaryEn, insightKo, insightEn — all strings, all
+ * optional. Missing fields gracefully fall back to the RSS excerpt.
  *
  * Usage:
- *   node scripts/generate-daily-digest.mjs            # today (KST)
+ *   node scripts/generate-daily-digest.mjs                 # today (KST), excerpts
  *   node scripts/generate-daily-digest.mjs --date 2026-06-14
+ *   node scripts/generate-daily-digest.mjs --enrich        # use AI fields if present
+ *   npm run digest -- --enrich                             # same, via npm
  *
  * If the data file is missing or has no articles, it exits 0 without writing.
  * Re-running on the same day overwrites the same files (idempotent).
@@ -61,15 +74,35 @@ function frontmatter({ title, description, date, tags }) {
   ].join('\n');
 }
 
-function buildMarkdown(lang, { date, articles }) {
+function buildMarkdown(lang, { date, articles }, enrich = false) {
   const isEn = lang === 'en';
   const L = {
     headline: isEn ? '🔥 Top Story' : '🔥 오늘의 주요 소식',
     quick: isEn ? '⚡ Quick News' : '⚡ 빠른 소식',
     readMore: isEn ? 'Read more' : '원문 보기',
-    footer: isEn
-      ? '_This digest was automatically collected from RSS feeds. Excerpts are taken verbatim from each source — see the original links for full details._'
-      : '_이 다이제스트는 RSS 피드에서 자동 수집되었습니다. 발췌문은 각 피드 원문에서 그대로 가져온 것으로, 자세한 내용은 원문 링크를 확인하세요._',
+    why: isEn ? 'Why it matters' : '왜 중요한가',
+    footer: enrich
+      ? isEn
+        ? '_This digest was collected from RSS feeds and summarized by AI (Claude). See the original links for full details._'
+        : '_이 다이제스트는 RSS 피드에서 수집한 뒤 AI(Claude)가 요약·정리했습니다. 자세한 내용은 원문 링크를 확인하세요._'
+      : isEn
+        ? '_This digest was automatically collected from RSS feeds. Excerpts are taken verbatim from each source — see the original links for full details._'
+        : '_이 다이제스트는 RSS 피드에서 자동 수집되었습니다. 발췌문은 각 피드 원문에서 그대로 가져온 것으로, 자세한 내용은 원문 링크를 확인하세요._',
+  };
+
+  // Body text: prefer the AI summary when enriching, else fall back to excerpt.
+  const summaryOf = (a) => {
+    if (enrich) {
+      const s = isEn ? a.summaryEn : a.summaryKo;
+      if (s && String(s).trim()) return String(s).trim();
+    }
+    return a.excerpt ? String(a.excerpt).trim() : '';
+  };
+  // Insight only appears in enrich mode and only when the field is present.
+  const insightOf = (a) => {
+    if (!enrich) return '';
+    const s = isEn ? a.insightEn : a.insightKo;
+    return s && String(s).trim() ? String(s).trim() : '';
   };
 
   const top = articles[0];
@@ -80,23 +113,28 @@ function buildMarkdown(lang, { date, articles }) {
   // Headline / top story
   lines.push(`## ${L.headline}`, '');
   lines.push(`### ${top.title}`, '');
-  if (top.excerpt) lines.push(top.excerpt, '');
+  const topBody = summaryOf(top);
+  if (topBody) lines.push(topBody, '');
+  const topInsight = insightOf(top);
+  if (topInsight) lines.push(`> 💡 **${L.why}**: ${topInsight}`, '');
   lines.push(`🔗 [${L.readMore}](${top.link}) · _${top.source}_`, '');
 
-  // Categorized sections — articles (excl. top) that carry an excerpt.
-  const detailed = rest.filter((a) => a.excerpt);
+  // Categorized sections — articles (excl. top) that have body text.
+  const detailed = rest.filter((a) => summaryOf(a));
   for (const cat of CATEGORIES) {
     const inCat = detailed.filter((a) => categoryForSource(a.source) === cat.key);
     if (inCat.length === 0) continue;
     lines.push('---', '', `## ${categoryLabel(cat.key, lang)}`, '');
     for (const a of inCat) {
       lines.push(`### [${a.title}](${a.link})`, '', `_${a.source}_`, '');
-      lines.push(a.excerpt, '');
+      lines.push(summaryOf(a), '');
+      const ins = insightOf(a);
+      if (ins) lines.push(`> 💡 ${ins}`, '');
     }
   }
 
-  // Quick news — everything else (no excerpt available), as compact bullets.
-  const briefs = rest.filter((a) => !a.excerpt);
+  // Quick news — everything else (no body text available), as compact bullets.
+  const briefs = rest.filter((a) => !summaryOf(a));
   if (briefs.length) {
     lines.push('---', '', `## ${L.quick}`, '');
     for (const a of briefs) {
@@ -122,8 +160,9 @@ function buildMarkdown(lang, { date, articles }) {
 
 function main() {
   const date = parseDateArg();
+  const enrich = process.argv.includes('--enrich');
   const dataPath = path.join(DATA_DIR, `${date}.json`);
-  log(`generating digest markdown for ${date}`);
+  log(`generating digest markdown for ${date}${enrich ? ' (enrich mode)' : ''}`);
 
   if (!fs.existsSync(dataPath)) {
     log(`no collected data at ${path.relative(process.cwd(), dataPath)} — run "npm run digest:collect" first. Skipping (no files written).`);
@@ -140,12 +179,21 @@ function main() {
   fs.mkdirSync(POSTS_DIR, { recursive: true });
   const koPath = path.join(POSTS_DIR, `daily-digest-${date}.md`);
   const enPath = path.join(POSTS_DIR, `daily-digest-${date}-en.md`);
-  fs.writeFileSync(koPath, buildMarkdown('ko', { date, articles }), 'utf-8');
-  fs.writeFileSync(enPath, buildMarkdown('en', { date, articles }), 'utf-8');
+  fs.writeFileSync(koPath, buildMarkdown('ko', { date, articles }, enrich), 'utf-8');
+  fs.writeFileSync(enPath, buildMarkdown('en', { date, articles }, enrich), 'utf-8');
+
+  // In enrich mode, report how many articles actually carried AI fields.
+  const enrichedCount = enrich
+    ? articles.filter((a) => a.summaryKo || a.summaryEn || a.insightKo || a.insightEn).length
+    : 0;
 
   log(`wrote ${path.relative(process.cwd(), koPath)}`);
   log(`wrote ${path.relative(process.cwd(), enPath)}`);
-  log(`done: ${articles.length} article(s)`);
+  log(
+    enrich
+      ? `done: ${articles.length} article(s), ${enrichedCount} with AI fields`
+      : `done: ${articles.length} article(s)`,
+  );
 }
 
 main();


### PR DESCRIPTION
## 목적 — Phase 2 (Cowork 스케줄 태스크 연동, 방식 A)

Cowork 스케줄 태스크가 수집된 JSON을 읽어 **Claude가 직접 요약+인사이트를 작성**하고, 그 결과로 더 풍부한 다이제스트 마크다운을 생성하는 방식을 지원합니다. (Claude 구독으로 커버 → 추가 API 비용 0)

## 변경 내용

### `generate-daily-digest.mjs` — `--enrich` 옵션 추가
- JSON 각 기사에 `summaryKo` / `summaryEn` / `insightKo` / `insightEn`가 있으면 이를 사용해 풍부한 마크다운 생성.
- 해당 필드가 없으면 **기존 원문 발췌(excerpt)로 필드 단위 폴백** — 하위 호환.
- 인사이트는 `> 💡 왜 중요한가` 블록으로 표시.
- enrich 모드 푸터는 "AI(Claude)가 요약·정리"임을 명시.
- 사용법: `npm run digest -- --enrich`

### `collect-feeds.mjs` — JSON 스키마 문서화
- 출력 JSON 스키마를 주석으로 문서화 (선택적 enrich 필드 포함).

### `docs/daily-digest.md` (신규)
- 전체 파이프라인, JSON 스키마, 폴백 규칙, Cowork 스케줄 태스크 작성 예시, 카테고리 매핑 가이드.

## Cowork 연동 흐름

```
1. .digest-data/YYYY-MM-DD.json 읽기
2. Claude가 각 기사에 summaryKo/insightKo 등 추가 → JSON 덮어쓰기
3. npm run digest -- --enrich → 보강된 마크다운 재생성
```

## 검증

- **enrich (필드 있음)**: 요약 + `💡 왜 중요한가` 인사이트 출력 (KO/EN)
- **폴백 (필드 없음)**: 원문 발췌로 대체, 인사이트 생략
- **bare (발췌도 없음)**: `⚡ 빠른 소식` 불릿으로 노출
- **기본 모드 (`--enrich` 없음)**: 동작 무변화 (인사이트 0건, 발췌 푸터)

> 참고: 이 브랜치는 main 기반입니다. 행 수정/보일러플레이트 제거는 #4에서 별도 처리하며, 변경 파일이 겹치지 않아 충돌 없이 머지됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
